### PR TITLE
Enhance portfolio site with about section and performance tweaks

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Mayank Sharma
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 A minimal Flask + Three.js portfolio showcasing projects and experience with a dynamic 3D torus knot background and starfield.
 
+## Features
+
+- Responsive hero, about, and project sections fed by a single Python resume file.
+- Compressed responses and cache headers via `Flask-Compress` for faster loads.
+
 ## Run locally
 
 ```bash
@@ -23,3 +28,7 @@ static/
   js/
     main.js
 ```
+
+## License
+
+Released under the [MIT License](LICENSE) © 2024 Mayank Sharma.

--- a/app.py
+++ b/app.py
@@ -1,10 +1,16 @@
 from flask import Flask, render_template
+from flask_compress import Compress
 
 app = Flask(__name__)
+Compress(app)
 
 resume = {
     "name": "Mayank Sharma",
     "title": "Machine Learning & Generative AI Engineer",
+    "summary": (
+        "Engineer delivering reliable AI systems and performant web apps for "
+        "enterprise environments."
+    ),
     "contact": {
         "email": "mayanksharma.cbs@gmail.com",
         "phone": "+91-8800460941",
@@ -117,6 +123,12 @@ resume = {
 @app.route("/")
 def index():
     return render_template("index.html", data=resume)
+
+
+@app.after_request
+def add_header(response):
+    response.headers["Cache-Control"] = "public, max-age=3600"
+    return response
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Flask==3.0.3
+Flask-Compress==1.13

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -27,6 +27,7 @@ main { position: relative; }
 .screen { min-height: 100vh; padding: 88px 20px 40px; display: grid; place-items: center; }
 .hero h1 { font-size: clamp(36px, 7vw, 80px); margin: 0; }
 .subtitle { font-size: clamp(18px, 2.4vw, 26px); color: var(--muted); margin: 6px 0 16px; }
+.lead { font-size: clamp(20px, 2.5vw, 28px); color: var(--muted); }
 .pills { display: flex; flex-wrap: wrap; gap: 8px; }
 .pill { border: 1px solid var(--glass-b); background: var(--glass); padding: 6px 10px; border-radius: 999px; color: var(--ink); text-decoration: none; }
 .cta { display: inline-block; margin-top: 16px; padding: 10px 14px; border-radius: 14px; background: #1d4ed8; color: white; text-decoration: none; }

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,6 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{{ data.name }} — Portfolio</title>
   <meta name="description" content="{{ data.title }}" />
+  <meta property="og:title" content="{{ data.name }} — Portfolio" />
+  <meta property="og:description" content="{{ data.title }}" />
+  <link rel="preconnect" href="https://unpkg.com" />
   <link rel="stylesheet" href="/static/css/style.css" />
   <!-- Three.js CDN (no bundler needed) -->
   <script defer src="https://unpkg.com/three@0.160.0/build/three.min.js"></script>
@@ -17,6 +20,7 @@
   <header class="nav">
     <div class="brand">MS</div>
     <nav>
+      <a href="#about">About</a>
       <a href="#experience">Experience</a>
       <a href="#projects">Projects</a>
       <a href="#skills">Skills</a>
@@ -40,6 +44,12 @@
         {% if data.contact.portfolio %}<a class="pill" target="_blank" rel="noopener noreferrer" href="{{ data.contact.portfolio }}">Portfolio</a>{% endif %}
       </div>
       <a class="cta" href="#projects">Explore my work →</a>
+    </section>
+
+    <!-- ABOUT -->
+    <section id="about" class="screen">
+      <h2>About</h2>
+      <p class="lead">{{ data.summary }}</p>
     </section>
 
     <!-- EXPERIENCE -->


### PR DESCRIPTION
## Summary
- add "About" section backed by new summary field
- speed up responses with Flask-Compress and cache headers
- document project and license it under MIT

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0a3f7cd2c8324ad19b87bb7541bce